### PR TITLE
typos in "Cite a reference..."

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,9 +101,9 @@ with no space after `https:`, `doi:`, `arXiv:` and angle brackets for auto-linki
 
 ### Documentation 
 
-#### Use canonical and https url 
+#### Use canonical and https URL 
 
-If there are some urls in your documentation, be sure to: 
+If there are some URLs in your documentation, be sure to: 
 
 + use https
 + use the canonical form for CRAN package (i.e.: https://CRAN.R-project.org/package=***)

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ If a function name is used in your DESCRIPTION, make sure to follow it with pare
 
 #### Cite a reference for implementation of a method or linking to a service.
 
-If you write an R interface to an API or implement an algorithm from a published article/book, add an reference to the publication as a DOI, ISBN, or similar canonical link, or UR for the API or article in the 'Description' field of your DESCRIPTION file.
+If you write an R interface to an API or implement an algorithm from a published article/book, add a reference to the publication as a DOI, ISBN, or similar canonical link, or URL for the API or article in the 'Description' field of your DESCRIPTION file.
 
 #### Use angle brackets for auto linking
 


### PR DESCRIPTION
This fixes two typos. 

I also capitalised URL for consistency. 