### PR TITLE
Don't wrap example in `if (FALSE)`

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ You can use `checkhelper::find_missing_tags()` to help you find the missing tags
 ### About \dontrun{} 
 
 `\dontrun{}` elements in the examples might in fact be run by CRAN. 
-If you don't want an example to be run, wrap it between `if (interactive()) {}`.
+If you don't want an example to be run, wrap it between `if (interactive()) {}`. Do not wrap example between `if (FALSE) {}`.
 
 ### Use canonical and https URL 
 


### PR DESCRIPTION
I have submitted a package to CRAN with example wrap in `if (FALSE)`.
CRAN member told me never to do that. I've switched to `\dontrun{}` and they accepted.

Since pkgdown site seems to render example in `\dontrun{}` to `if (FALSE) {}`. For example, see [examples section in this function](https://pkgs.rstudio.com/rmarkdown/reference/pdf_document.html) and [the source](https://github.com/rstudio/rmarkdown/blob/HEAD/R/pdf_document.R). 

Some R user (including me) who did't read function docs carefully might mislead that it OK to wrap example in `if (FALSE) {}`. 

Therefore, I suggest adding a little warning as it might be informative to someone.

Thank you.



